### PR TITLE
Knock link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Hi there 👋
 
-On occassion, I find time to contribute to open source projects. Currently, those occassions are few and limited. During "normal business hours," in the United States eastern timezone, I am focused on helping improve people's lives through [knock.com](knock.com). During such hours, I **will not** merge pull requests and issue new releases of any modules I maintain. Such activities must wait until I am able to find time during evenings, weekends, and holidays.
+On occassion, I find time to contribute to open source projects. Currently, those occassions are few and limited. During "normal business hours," in the United States eastern timezone, I am focused on helping improve people's lives through [knock.com](https://www.knock.com/). During such hours, I **will not** merge pull requests and issue new releases of any modules I maintain. Such activities must wait until I am able to find time during evenings, weekends, and holidays.
 
 If you are here because you are having an issue with one of my modules, you will be helped much quicker if you can provide a pull request to fix the issue.


### PR DESCRIPTION
W/o https, link leads to the https://github.com/jsumners/jsumners/blob/master/knock.com